### PR TITLE
feat: centralize theme variables

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1,8 +1,9 @@
-*{box-sizing:border-box} body{font-family:system-ui,Segoe UI,Roboto,Arial,sans-serif;margin:0;background:#0b1220;color:#e6eef8}
-header{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:#0e172a;border-bottom:1px solid #1f2a44}
+@import './theme.css';
+*{box-sizing:border-box} body{font-family:var(--font-family);margin:0;background:var(--background-color);color:var(--text-color)}
+header{display:flex;align-items:center;justify-content:space-between;padding:12px 16px;background:var(--color-primary);border-bottom:1px solid #1f2a44}
 h1{font-size:18px;margin:0} nav{display:flex;gap:8px}
-nav .tab-btn{background:#19233b;color:#e6eef8;border:1px solid #243256;border-radius:10px;padding:8px 12px;cursor:pointer}
-nav .tab-btn.active, nav .tab-btn:hover{background:#243256}
+nav .tab-btn{background:#19233b;color:var(--text-color);border:1px solid var(--color-secondary);border-radius:10px;padding:8px 12px;cursor:pointer}
+nav .tab-btn.active, nav .tab-btn:hover{background:var(--color-secondary)}
 main{padding:16px}
 .tab{display:none} .tab.active{display:block}
 .cards{display:grid;grid-template-columns:repeat(3,1fr);gap:12px}
@@ -12,20 +13,20 @@ main{padding:16px}
 .unit-panel .left{flex:1}
 .unit-panel .right{width:320px}
 .toolbar{display:flex;gap:8px;margin:8px 0}
-table{width:100%;border-collapse:collapse;background:#0e172a;border:1px solid #213057;border-radius:10px;overflow:hidden}
+table{width:100%;border-collapse:collapse;background:var(--color-primary);border:1px solid #213057;border-radius:10px;overflow:hidden}
 th,td{padding:8px;border-bottom:1px solid #1b2a4a}
-button{background:#22345a;color:#e6eef8;border:1px solid #2f477a;border-radius:10px;padding:8px 12px;cursor:pointer}
+button{background:#22345a;color:var(--text-color);border:1px solid #2f477a;border-radius:10px;padding:8px 12px;cursor:pointer}
 button:hover{background:#2a4275}
-input,select{background:#0e172a;color:#e6eef8;border:1px solid #2a3c66;border-radius:8px;padding:6px;width:100%}
+input,select{background:var(--color-primary);color:var(--text-color);border:1px solid #2a3c66;border-radius:8px;padding:6px;width:100%}
 .modal{position:fixed;inset:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center}
-.modal .modal-content{background:#0e172a;border:1px solid #213057;border-radius:12px;padding:16px;min-width:520px}
+.modal .modal-content{background:var(--color-primary);border:1px solid #213057;border-radius:12px;padding:16px;min-width:520px}
 .hidden{display:none}
 .grid{display:grid;grid-template-columns:repeat(2,1fr);gap:8px}
 .right{display:flex;justify-content:flex-end;gap:8px;margin-top:8px}
 .badge{display:inline-block;padding:2px 6px;border:1px solid #2a3c66;border-radius:6px;margin-left:8px;font-size:12px}
-pre{background:#0e172a;border:1px solid #213057;border-radius:12px;padding:8px;overflow:auto;max-height:280px}
+pre{background:var(--color-primary);border:1px solid #213057;border-radius:12px;padding:8px;overflow:auto;max-height:280px}
 .user-badge{font-size:12px;opacity:.85;border:1px solid #2a3c66;border-radius:8px;padding:4px 8px}
 .auth-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:1000}
-.auth-card{background:#0e172a;border:1px solid #213057;border-radius:12px;padding:16px;min-width:320px;display:flex;flex-direction:column;gap:8px}
+.auth-card{background:var(--color-primary);border:1px solid #213057;border-radius:12px;padding:16px;min-width:320px;display:flex;flex-direction:column;gap:8px}
 .auth-card h2{margin:0 0 8px 0}
 .auth-error{color:#ff8a80;font-size:12px;min-height:16px}

--- a/src/renderer/theme.css
+++ b/src/renderer/theme.css
@@ -1,0 +1,7 @@
+:root {
+  --color-primary: #0e172a;
+  --color-secondary: #243256;
+  --background-color: #0b1220;
+  --text-color: #e6eef8;
+  --font-family: system-ui, 'Segoe UI', Roboto, Arial, sans-serif;
+}


### PR DESCRIPTION
## Summary
- define shared EMIAS color palette and font family in new `theme.css`
- import theme variables into renderer styles and replace hard-coded colors

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a615679470832081a4baf50eb6ba19